### PR TITLE
Fixing vitest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
 			"devDependencies": {
 				"@sveltejs/adapter-auto": "^3.1.1",
 				"@sveltejs/kit": "^2.5.0",
+				"@sveltejs/vite-plugin-svelte": "^3.0.2",
 				"@typescript-eslint/eslint-plugin": "^6.0.0",
 				"@typescript-eslint/parser": "^6.0.0",
 				"eslint": "^8.28.0",
@@ -829,7 +830,6 @@
 			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte/-/vite-plugin-svelte-3.0.2.tgz",
 			"integrity": "sha512-MpmF/cju2HqUls50WyTHQBZUV3ovV/Uk8k66AN2gwHogNAG8wnW8xtZDhzNBsFJJuvmq1qnzA5kE7YfMJNFv2Q==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@sveltejs/vite-plugin-svelte-inspector": "^2.0.0",
 				"debug": "^4.3.4",
@@ -852,7 +852,6 @@
 			"resolved": "https://registry.npmjs.org/@sveltejs/vite-plugin-svelte-inspector/-/vite-plugin-svelte-inspector-2.0.0.tgz",
 			"integrity": "sha512-gjr9ZFg1BSlIpfZ4PRewigrvYmHWbDrq2uvvPB1AmTWKuM+dI1JXQSUu2pIrYLb/QncyiIGkFDFKTwJ0XqQZZg==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"debug": "^4.3.4"
 			},
@@ -1608,7 +1607,6 @@
 			"resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
 			"integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -3353,7 +3351,6 @@
 			"resolved": "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.15.3.tgz",
 			"integrity": "sha512-41snaPswvSf8TJUhlkoJBekRrABDXDMdpNpT2tfHIv4JuhgvHqLMhEPGtaQn0BmbNSTkuz2Ed20DF2eHw0SmBQ==",
 			"dev": true,
-			"peer": true,
 			"engines": {
 				"node": "^12.20 || ^14.13.1 || >= 16"
 			},
@@ -3670,7 +3667,6 @@
 			"resolved": "https://registry.npmjs.org/vitefu/-/vitefu-0.2.5.tgz",
 			"integrity": "sha512-SgHtMLoqaeeGnd2evZ849ZbACbnwQCIwRH57t18FxcXoZop0uQu0uzlIhJBlF/eWVzuce0sHeqPcDo+evVcg8Q==",
 			"dev": true,
-			"peer": true,
 			"peerDependencies": {
 				"vite": "^3.0.0 || ^4.0.0 || ^5.0.0"
 			},

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 	"devDependencies": {
 		"@sveltejs/adapter-auto": "^3.1.1",
 		"@sveltejs/kit": "^2.5.0",
+		"@sveltejs/vite-plugin-svelte": "^3.0.2",
 		"@typescript-eslint/eslint-plugin": "^6.0.0",
 		"@typescript-eslint/parser": "^6.0.0",
 		"eslint": "^8.28.0",

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,18 +1,18 @@
 import adapter from '@sveltejs/adapter-auto';
-import { vitePreprocess } from '@sveltejs/kit/vite';
+import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-	// Consult https://kit.svelte.dev/docs/integrations#preprocessors
-	// for more information about preprocessors
-	preprocess: vitePreprocess(),
+ // Consult https://kit.svelte.dev/docs/integrations#preprocessors
+ // for more information about preprocessors
+ preprocess: vitePreprocess(),
 
-	kit: {
-		// adapter-auto only supports some environments, see https://kit.svelte.dev/docs/adapter-auto for a list.
-		// If your environment is not supported or you settled on a specific environment, switch out the adapter.
-		// See https://kit.svelte.dev/docs/adapters for more information about adapters.
-		adapter: adapter()
-	}
+ kit: {
+  // adapter-auto only supports some environments, see https://kit.svelte.dev/docs/adapter-auto for a list.
+  // If your environment is not supported or you settled on a specific environment, switch out the adapter.
+  // See https://kit.svelte.dev/docs/adapters for more information about adapters.
+  adapter: adapter()
+ }
 };
 
 export default config;


### PR DESCRIPTION
After upgrade to vite ^5.0.3, running `npm run test` produced following error:

```
file:///Users/kevinokamoto/Projects/Svelte/stitched/svelte.config.js?ts=1708797371628:2
import { vitePreprocess } from '@sveltejs/kit/vite';
         ^^^^^^^^^^^^^^
SyntaxError: The requested module '@sveltejs/kit/vite' does not provide an export named 'vitePreprocess'
    at ModuleJob._instantiate (node:internal/modules/esm/module_job:131:21)
    at async ModuleJob.run (node:internal/modules/esm/module_job:213:5)
    at async ModuleLoader.import (node:internal/modules/esm/loader:316:24)
    at async load_config (file:///Users/kevinokamoto/Projects/Svelte/stitched/node_modules/@sveltejs/kit/src/core/config/index.js:70:17)
    at async sveltekit (file:///Users/kevinokamoto/Projects/Svelte/stitched/node_modules/@sveltejs/kit/src/exports/vite/index.js:148:24)
    at async Promise.all (index 0)
    at async asyncFlatten (file:///Users/kevinokamoto/Projects/Svelte/stitched/node_modules/vite/dist/node/chunks/dep-jDlpJiMN.js:12929:16)
    at async resolveConfig (file:///Users/kevinokamoto/Projects/Svelte/stitched/node_modules/vite/dist/node/chunks/dep-jDlpJiMN.js:67644:29)
    at async _createServer (file:///Users/kevinokamoto/Projects/Svelte/stitched/node_modules/vite/dist/node/chunks/dep-jDlpJiMN.js:64257:20)
    at async createViteServer (file:///Users/kevinokamoto/Projects/Svelte/stitched/node_modules/vitest/dist/vendor-node.a7c48fe1.js:10587:18)
```

Based on documentation [here](https://kit.svelte.dev/docs/integrations#preprocessors). I installed `@sveltejs/vite-plugin-svelte` and changed import statement to:

```js
import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
```